### PR TITLE
Fix issues observed in mumford

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 test-output
 gumshoe.log
 dependency-reduced-pom.xml
+.DS_Store

--- a/java/src/main/java/com/bazaarvoice/gumshoe/Configuration.java
+++ b/java/src/main/java/com/bazaarvoice/gumshoe/Configuration.java
@@ -2,26 +2,26 @@ package com.bazaarvoice.gumshoe;
 
 /**
  * Interface of objects that can be used to configure Gumshoe.
- * 
+ *
  * @author lance.woodson
  *
  */
 public interface Configuration {
     /**
      * The name of the application
-     * 
+     *
      * @return
      */
     String getApplicationName();
     /**
      * Object that decides whether an event will be published or not
-     * 
+     *
      * @return
      */
     Filter getFilter();
     /**
      * Object that decorates all events with global information
-     * 
+     *
      * @return
      */
     Decorator getDecorator();
@@ -30,4 +30,11 @@ public interface Configuration {
      * @return
      */
     Publisher getPublisher();
+
+    /**
+     * Maximum depth of the context stack before exceptions occur
+     *
+     * @return
+     */
+    int getMaxContextStackDepth();
 }

--- a/java/src/main/java/com/bazaarvoice/gumshoe/Context.java
+++ b/java/src/main/java/com/bazaarvoice/gumshoe/Context.java
@@ -25,6 +25,7 @@ public class Context {
     public static enum Status {
         CREATED, STARTED, FINISHED;
     }
+    private Gumshoe gumshoe;
     private UUID streamId;
     private String name;
     private EventFactory eventFactory;
@@ -43,8 +44,8 @@ public class Context {
      * @param eventFactory
      * @param eventDispatcher
      */
-    public Context(String name, EventFactory eventFactory, EventHandler eventDispatcher) {
-        this(UUID.randomUUID(), name, eventFactory, eventDispatcher);
+    public Context(Gumshoe gumshoe, String name, EventFactory eventFactory, EventHandler eventDispatcher) {
+        this(gumshoe, UUID.randomUUID(), name, eventFactory, eventDispatcher);
     }
 
     /**
@@ -55,7 +56,7 @@ public class Context {
      * @param previous
      */
     public Context(String name, Context previous) {
-        this(previous.streamId, name, previous.eventFactory, previous.eventDispatcher);
+        this(previous.gumshoe, previous.streamId, name, previous.eventFactory, previous.eventDispatcher);
         this.streamId = previous.streamId;
         this.name = name;
         this.eventFactory = previous.eventFactory;
@@ -77,7 +78,8 @@ public class Context {
      * @param eventFactory
      * @param eventDispatcher
      */
-    public Context(UUID streamId, String name, EventFactory eventFactory, EventHandler eventDispatcher) {
+    public Context(Gumshoe gumshoe, UUID streamId, String name, EventFactory eventFactory, EventHandler eventDispatcher) {
+        this.gumshoe = gumshoe;
         this.streamId = streamId;
         this.name = name;
         this.eventFactory = eventFactory;
@@ -199,7 +201,7 @@ public class Context {
         finishedTime = System.currentTimeMillis();
         event.put(Attribute.named("elapsed"), finishedTime - startTime);
         eventDispatcher.handle(event);
-        Gumshoe.get().pop();
+        gumshoe.pop();
         eventFactory.getDataStack().pop();
 
         return this;

--- a/java/src/main/java/com/bazaarvoice/gumshoe/Context.java
+++ b/java/src/main/java/com/bazaarvoice/gumshoe/Context.java
@@ -33,7 +33,6 @@ public class Context {
     Map<String, Object> data;
     private Long startTime;
     private Long finishedTime;
-    Gumshoe governor;
 
     /**
      * Construct a context with the specified name, event factory and event dispatcher.

--- a/java/src/main/java/com/bazaarvoice/gumshoe/ContextStackDepthException.java
+++ b/java/src/main/java/com/bazaarvoice/gumshoe/ContextStackDepthException.java
@@ -1,0 +1,13 @@
+package com.bazaarvoice.gumshoe;
+
+/**
+ * Indicates that a maximum context stack depth has been exceeded
+ *
+ * @author lance.woodson
+ *
+ */
+public class ContextStackDepthException extends RuntimeException {
+    public ContextStackDepthException(int size) {
+        super(String.format("Context depth of %s exceeded", size));
+    }
+}

--- a/java/src/main/java/com/bazaarvoice/gumshoe/Gumshoe.java
+++ b/java/src/main/java/com/bazaarvoice/gumshoe/Gumshoe.java
@@ -104,8 +104,8 @@ public class Gumshoe {
         } else {
             context = new Context(name, contexts.peek());
         }
-        contexts.push(context);
         ensureContextStackDepthNotExceeeded();
+        contexts.push(context);
 
         return context;
     }
@@ -188,7 +188,7 @@ public class Gumshoe {
     }
 
     private void ensureContextStackDepthNotExceeeded() {
-        if (contexts.size() > maxContextStackDepth) {
+        if (contexts.size() >= maxContextStackDepth) {
             throw new ContextStackDepthException(maxContextStackDepth);
         }
     }

--- a/java/src/main/java/com/bazaarvoice/gumshoe/Gumshoe.java
+++ b/java/src/main/java/com/bazaarvoice/gumshoe/Gumshoe.java
@@ -46,7 +46,7 @@ public class Gumshoe {
         }
 
         Gumshoe instance = instances.get();
-        if (instances.get() == null) {
+        if (instance == null) {
             EventFactory eventFactory = new EventFactory();
             EventHandler eventHandler = new EventHandler(getConfiguration());
             instance = new Gumshoe(eventFactory, eventHandler);
@@ -83,7 +83,7 @@ public class Gumshoe {
             throw new IllegalStateException("StreamId already set in within previous context");
         }
 
-        Context context = new Context(streamId, name, eventFactory, eventHandler);
+        Context context = new Context(this, streamId, name, eventFactory, eventHandler);
         contexts.push(context);
         return context;
     }
@@ -98,7 +98,7 @@ public class Gumshoe {
         Context context;
 
         if (contexts.isEmpty()) {
-            context = new Context(name, eventFactory, eventHandler);
+            context = new Context(this, name, eventFactory, eventHandler);
         } else {
             context = new Context(name, contexts.peek());
         }

--- a/java/src/main/java/com/bazaarvoice/gumshoe/Gumshoe.java
+++ b/java/src/main/java/com/bazaarvoice/gumshoe/Gumshoe.java
@@ -49,7 +49,7 @@ public class Gumshoe {
         if (instance == null) {
             EventFactory eventFactory = new EventFactory();
             EventHandler eventHandler = new EventHandler(getConfiguration());
-            instance = new Gumshoe(eventFactory, eventHandler);
+            instance = new Gumshoe(eventFactory, eventHandler, configuration.getMaxContextStackDepth());
             instances.set(instance);
         }
         return instance;
@@ -64,10 +64,12 @@ public class Gumshoe {
     EventFactory eventFactory;
     EventHandler eventHandler;
     Stack<Context> contexts;
+    int maxContextStackDepth;
 
-    private Gumshoe(EventFactory eventFactory, EventHandler eventHandler) {
+    private Gumshoe(EventFactory eventFactory, EventHandler eventHandler, int maxContextStackDepth) {
         this.eventFactory = eventFactory;
         this.eventHandler = eventHandler;
+        this.maxContextStackDepth = maxContextStackDepth;
         contexts = new Stack<Context>();
     }
 
@@ -103,6 +105,7 @@ public class Gumshoe {
             context = new Context(name, contexts.peek());
         }
         contexts.push(context);
+        ensureContextStackDepthNotExceeeded();
 
         return context;
     }
@@ -182,5 +185,11 @@ public class Gumshoe {
      */
     public void emit(String type) {
         contexts.peek().emit(type);
+    }
+
+    private void ensureContextStackDepthNotExceeeded() {
+        if (contexts.size() > maxContextStackDepth) {
+            throw new ContextStackDepthException(maxContextStackDepth);
+        }
     }
 }

--- a/java/src/main/java/com/bazaarvoice/gumshoe/SimpleConfiguration.java
+++ b/java/src/main/java/com/bazaarvoice/gumshoe/SimpleConfiguration.java
@@ -15,11 +15,13 @@ public class SimpleConfiguration implements Configuration {
     private Filter filter;
     private Decorator decorator;
     private Publisher publisher;
+    private int maxContextStackDepth;
 
     /**
      * Create a new SimpleConfiguration for the application using a
      * NoOpFilter, SimpleDecorator and PrintStreamPublisher to publish
-     * events to standard out.
+     * events to standard out.  A maximum context stack depth of 50
+     * will be enforced.
      *
      * @param applicationName
      */
@@ -28,12 +30,14 @@ public class SimpleConfiguration implements Configuration {
         this.filter = new NoOpFilter();
         this.decorator = new SimpleDecorator(applicationName);
         this.publisher = new PrintStreamPublisher();
+        this.maxContextStackDepth = 50;
     }
 
     /**
      * Create a new SimpleConfiguration for the application using
      * a NoOpFilter, SimpleDecorator and EventLogPublisher that publishes
-     * events to the file at the specified path.
+     * events to the file at the specified path.  A max context stack depth
+     * of 50 will be enforced.
      *
      * @param applicationName
      * @param logPath
@@ -43,6 +47,7 @@ public class SimpleConfiguration implements Configuration {
         this.filter = new NoOpFilter();
         this.decorator = new SimpleDecorator(applicationName);
         this.publisher = new EventLogPublisher(logPath);
+        this.maxContextStackDepth = 50;
     }
 
     @Override
@@ -75,5 +80,14 @@ public class SimpleConfiguration implements Configuration {
 
     public void setPublisher(Publisher publisher) {
         this.publisher = publisher;
+    }
+
+    @Override
+    public int getMaxContextStackDepth() {
+        return maxContextStackDepth;
+    }
+
+    public void setMaxContextStackDepth(int maxContentStackDepth) {
+        this.maxContextStackDepth = maxContentStackDepth;
     }
 }

--- a/java/src/test/java/com/bazaarvoice/gumshoe/ContextTest.java
+++ b/java/src/test/java/com/bazaarvoice/gumshoe/ContextTest.java
@@ -21,7 +21,7 @@ public class ContextTest extends Assert {
         Gumshoe.configure(new SimpleConfiguration("test"));
         eventFactory = new EventFactory();
         eventHandler = mock(EventHandler.class);
-        context = new Context("context one", eventFactory, eventHandler);
+        context = new Context(Gumshoe.get(), "context one", eventFactory, eventHandler);
         secondContext = new Context("context two", context);
     }
 

--- a/java/src/test/java/com/bazaarvoice/gumshoe/GumshoeTest.java
+++ b/java/src/test/java/com/bazaarvoice/gumshoe/GumshoeTest.java
@@ -135,4 +135,12 @@ public class GumshoeTest extends Assert {
         //  one start event, one emit event
         verify(publisher, times(2)).publish(anyMap());
     }
+
+    @Test(expectedExceptions={ContextStackDepthException.class})
+    public void ensureMaxContextStackDepthEnforcedWhenCreatingContextByName() {
+        Gumshoe.configure(configuration);
+        for (int i = 0; i < Gumshoe.getConfiguration().getMaxContextStackDepth() + 1; i++) {
+            Gumshoe.get().context("ctx" + i);
+        }
+    }
 }

--- a/java/src/test/java/com/bazaarvoice/gumshoe/integration/MultiThreadedIntegrationTest.java
+++ b/java/src/test/java/com/bazaarvoice/gumshoe/integration/MultiThreadedIntegrationTest.java
@@ -43,7 +43,7 @@ public class MultiThreadedIntegrationTest extends Assert {
         when(filter.shouldDispatch(anyMap())).thenReturn(true);
     }
 
-    @Test(enabled=false)
+    @Test
     public void test() throws Exception {
         Counter counter1 = new Counter("counter1", 5);
         Counter counter2 = new Counter("counter2", 5);

--- a/java/src/test/java/com/bazaarvoice/gumshoe/integration/MultiThreadedIntegrationTest.java
+++ b/java/src/test/java/com/bazaarvoice/gumshoe/integration/MultiThreadedIntegrationTest.java
@@ -51,10 +51,15 @@ public class MultiThreadedIntegrationTest extends Assert {
         counter1.start();
         counter2.start();
 
-        Thread.sleep(2500);
-
+        long startTime = System.currentTimeMillis();
         List<Map<String, Object>> events = publisher.getEvents();
-        assertEquals(events.size(), 14);
+        do {
+            if ((System.currentTimeMillis() - startTime) > 15000) {
+                fail("Did not receive 14 events within 15 seconds");
+            }
+            events = publisher.getEvents();
+            Thread.sleep(25);
+        } while (events.size() < 14);
 
         List<Map<String, Object>> counter1Events = new ArrayList<Map<String,Object>>();
         List<Map<String, Object>> counter2Events = new ArrayList<Map<String,Object>>();


### PR DESCRIPTION
Fixes two primary issues observed in mumford when diagnosing a context stack memory leak:
1.  Modifies how a context removes itself from the stack of contexts in a Gumshoe instance to use a direct reference rather than trying to look it up.  This will help contexts to be finished properly and eliminate a memory leak.
2.  Introduces a maxContextStackDepth config value that defaults to 50.  Gumshoe will raise a `ContextStackDepthException` if this depth is exceeded.  Memory leaks are still possible if a user of the lib does not properly finish contexts.  This failure will be close(r) to the problem as opposed to what errors might arise when the app eventually runs out of memory.
3.  Also fixes the occasionally failing multi-threaded integration test by using polling instead of sleeps.
