### PR TITLE
Coerce Classes passed to gumshoe to their name before logging

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>1.4</version>
+      <version>2.6.1</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/java/src/main/java/com/bazaarvoice/gumshoe/EventLogPublisher.java
+++ b/java/src/main/java/com/bazaarvoice/gumshoe/EventLogPublisher.java
@@ -1,6 +1,7 @@
 package com.bazaarvoice.gumshoe;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.FileHandler;
@@ -9,6 +10,11 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 
 public class EventLogPublisher implements Publisher {
     private String path;
@@ -26,7 +32,13 @@ public class EventLogPublisher implements Publisher {
             logger = Logger.getLogger("gumshoe");
             logger.setUseParentHandlers(false);
             logger.addHandler(fileHandler);
-            gson = new Gson();
+            gson = new GsonBuilder().registerTypeAdapter(Class.class, new JsonSerializer<Class<?>>() {
+                @Override
+                public JsonElement serialize(Class<?> clazz, Type type,
+                        JsonSerializationContext ctx) {
+                    return new JsonPrimitive(clazz.getName());
+                }
+            }).create();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -39,6 +51,10 @@ public class EventLogPublisher implements Publisher {
 
     public String getPath() {
         return path;
+    }
+    
+    public void close() {
+        fileHandler.close();
     }
 
     private Formatter buildFormatter() {

--- a/java/src/test/java/com/bazaarvoice/gumshoe/EventLogPublisherTest.java
+++ b/java/src/test/java/com/bazaarvoice/gumshoe/EventLogPublisherTest.java
@@ -3,7 +3,9 @@ package com.bazaarvoice.gumshoe;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.testng.Assert;
@@ -11,10 +13,13 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.gson.Gson;
+
 public class EventLogPublisherTest extends Assert {
     private String path;
-    private Publisher publisher;
+    private EventLogPublisher publisher;
     private Map<String, Object> event;
+    private Gson gson;
 
     @BeforeMethod
     public void setUp() {
@@ -23,10 +28,12 @@ public class EventLogPublisherTest extends Assert {
         event = new HashMap<String, Object>();
         event.put("a", 1);
         event.put("b", 2);
+        gson = new Gson();
     }
 
     @AfterMethod
     public void tearDown() {
+        publisher.close();
         File logFile = new File(path);
         if (logFile.exists()) {
             logFile.delete();
@@ -36,8 +43,16 @@ public class EventLogPublisherTest extends Assert {
     @Test
     public void testEventsPublishedAsJSONToFile() throws Exception {
         publisher.publish(event);
-        String publishedEvents = new String(Files.readAllBytes(Paths.get(path)));
-        assertTrue(publishedEvents.contains("\"a\":1"));
-        assertTrue(publishedEvents.contains("\"b\":2"));
+        Map<String, Object> event = gson.fromJson(new String(Files.readAllBytes(Paths.get(path))), Map.class);
+        assertEquals(event.get("a"), 1.0);
+        assertEquals(event.get("b"), 2.0);
+    }
+   
+    @Test
+    public void ensureClassesSerializedCorrectly() throws Exception {
+        event.put("exception", new Exception().getClass());
+        publisher.publish(event);
+        String publishedEvent = new String(Files.readAllBytes(Paths.get(path)));
+        gson.fromJson(publishedEvent, Map.class);
     }
 }


### PR DESCRIPTION
Currently, passing a class as a value of an event to Gumshoe results in an `UnsupportedOperationException` because Gson does not know how to coerce a class object to a string.  This fixes the issue by coercing to the class name.

Fixes https://github.com/bazaarvoice/gumshoe/issues/17
