### PR TITLE
Fail contexts with an Exception to log details of the exception

### DIFF
--- a/java/src/test/java/com/bazaarvoice/gumshoe/ContextTest.java
+++ b/java/src/test/java/com/bazaarvoice/gumshoe/ContextTest.java
@@ -151,6 +151,24 @@ public class ContextTest extends Assert {
     }
 
     @Test
+    public void ensureFailWithExceptionSendsFailedEventWithExceptionDetails() {
+        RuntimeException ex = new RuntimeException("outter", new Exception("inner"));
+
+        context.start();
+        context.fail(ex);
+
+        Map<String, Object> failedEvent = buildExpectedEvent(context, "failed");
+        failedEvent.put(Attribute.named("exception"), "java.lang.RuntimeException");
+        failedEvent.put(Attribute.named("failure_message"), "outter");
+        failedEvent.put(Attribute.named("root_exception"), "java.lang.Exception");
+        failedEvent.put(Attribute.named("root_failure_message"), "inner");
+
+        verify(eventHandler).handle(buildExpectedEvent(context, "started"));
+        verify(eventHandler).handle(failedEvent);
+    }
+
+
+    @Test
     public void ensureFailUnloadsEventFactoryDataStack() {
         context.put("foo", "bar").start().fail();
 


### PR DESCRIPTION
We are currently doing this kind of logic to load a context with data and emit a failed event in CP, Mumford Submissions and Mumford.  This centralizes this logic into Gumshoe.

Fixes https://github.com/bazaarvoice/gumshoe/issues/15
