### PR TITLE
Execute callables within Gumshoe managed context

### DIFF
--- a/java/src/main/java/com/bazaarvoice/gumshoe/InContextException.java
+++ b/java/src/main/java/com/bazaarvoice/gumshoe/InContextException.java
@@ -1,0 +1,13 @@
+package com.bazaarvoice.gumshoe;
+
+/**
+ * Exception raised when an exception happens within a context.
+ *
+ * @author lance.woodson
+ *
+ */
+public class InContextException extends RuntimeException {
+    public InContextException(Exception cause) {
+        super(cause);
+    }
+}

--- a/java/src/main/java/com/bazaarvoice/gumshoe/VoidCallable.java
+++ b/java/src/main/java/com/bazaarvoice/gumshoe/VoidCallable.java
@@ -1,0 +1,11 @@
+package com.bazaarvoice.gumshoe;
+
+/**
+ * Interface of objects that can be invoked within a context
+ *
+ * @author lance.woodson
+ *
+ */
+public interface VoidCallable {
+    void call() throws Exception;
+}

--- a/java/src/test/java/com/bazaarvoice/gumshoe/ContextTest.java
+++ b/java/src/test/java/com/bazaarvoice/gumshoe/ContextTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.*;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 public class ContextTest extends Assert {
     private EventFactory eventFactory;
@@ -95,6 +96,85 @@ public class ContextTest extends Assert {
         context.put("foo", "bar").start();
 
         assertEquals(eventFactory.getDataStack().get("foo"), "bar");
+    }
+
+    @Test
+    public void ensureStartWithCallableReturnsCallableResult() {
+        String result = context.start(new Callable<String>() {
+            @Override
+            public String call() {
+                return "test";
+            }
+        });
+        assertEquals(result, "test");
+    }
+
+    @Test
+    public void ensureStartWithCallableFinishesStatus() {
+        context.start(new Callable<String>() {
+            @Override
+            public String call() {
+                return "test";
+            }
+        });
+        assertEquals(Context.Status.FINISHED, context.getStatus());
+    }
+
+    @Test(expectedExceptions={InContextException.class})
+    public void ensureStartWithCallableThrowingExceptionPropagatesException() {
+        context.start(new Callable<String>() {
+            @Override
+            public String call() {
+                throw new RuntimeException("Ooops, I did it again");
+            }
+        });
+    }
+
+    @Test
+    public void ensureStartWithCallableThrowingExceptionFinishesContext() {
+        try {
+            context.start(new Callable<String>() {
+                @Override
+                public String call() {
+                    throw new RuntimeException("Ooops, I did it again");
+                }
+            });
+        } catch (Exception e) { }
+        assertEquals(Context.Status.FINISHED, context.getStatus());
+    }
+
+    @Test
+    public void ensureStartWithVoidCallableFinishesContext() {
+        context.start(new VoidCallable() {
+            @Override
+            public void call() {
+               // do something
+            }
+        });
+        assertEquals(Context.Status.FINISHED, context.getStatus());
+    }
+
+    @Test(expectedExceptions={InContextException.class})
+    public void ensureStartWithVoidCallableThrowingExceptionPropagatesException() {
+        context.start(new VoidCallable() {
+            @Override
+            public void call() {
+                throw new RuntimeException("Ooops, I did it again");
+            }
+        });
+    }
+
+    @Test
+    public void ensureStartWithVoidCallableThrowingExceptionFinishesContext() {
+        try {
+            context.start(new VoidCallable() {
+                @Override
+                public void call() {
+                    throw new RuntimeException("Ooops, I did it again");
+                }
+            });
+        } catch (Exception e) { }
+        assertEquals(Context.Status.FINISHED, context.getStatus());
     }
 
     @Test(expectedExceptions={IllegalStateException.class})


### PR DESCRIPTION
Addresses issue #26 to give callback interfaces to be executed within a Gumshoe  managed context.  The context will start, execute the callable, finish the context (or fail it if exception) then return result (or propagate exception).

Two interfaces are supported -- the standard lib `Callable` interface when you care about a return value and the Gumshoe provided `VoidCallable` interface when you don't care about a return value.

This works w/anonymous classes:

``` java
context.start(new VoidCallable() {
    public void call() {
        // do something
    };
});
```

and java 8 lambda syntax:

``` java
context.start(() -> {
    // do something
});
```
